### PR TITLE
docs: add CLAUDE.md workflow directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules
 *.njsproj
 *.sln
 *.sw?
+
+# Git worktrees (used by Claude for branch-based development)
+worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# cessna-skyhawk
+
+Test data / sample aircraft records for development and testing.
+
+> **IMPORTANT:** Before beginning any work, read and follow the directives in [`../_solution/CLAUDE.md`](../_solution/CLAUDE.md). That file defines the required workflow for all Bluetail projects — do not skip it.
+
+> If `../_solution` does not exist, your Bluetail projects are not in the expected flat folder structure. All repos should be sibling directories (e.g., `bluetail/app`, `bluetail/backend`, `bluetail/_solution`).


### PR DESCRIPTION
## Summary
- Standardize CLAUDE.md across all projects with workflow directives pointing to `_solution` docs
- Add `worktrees/` to `.gitignore` for worktree-based development

## Changes
- Updated CLAUDE.md header to enforce reading `_solution/CLAUDE.md` before starting work
- Added `worktrees/` entry to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)