### PR TITLE
BT-9137 fix(deps): declare tippy.js as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-router": "6.30.3",
     "react-router-dom": "6.30.3",
     "react-toastify": "9.1.1",
+    "tippy.js": "6.3.7",
     "zustand": "4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-toastify:
         specifier: 9.1.1
         version: 9.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tippy.js:
+        specifier: 6.3.7
+        version: 6.3.7
       zustand:
         specifier: 4.3.6
         version: 4.3.6(immer@9.0.21)(react@18.2.0)


### PR DESCRIPTION
## Summary
Amplify build for #16's merge to \`dev\` failed with:

\`\`\`
Module not found: Error: Can't resolve 'tippy.js/dist/tippy.css'
\`\`\`

\`src/index.jsx\` imports \`tippy.js/dist/tippy.css\` directly but only \`@tippyjs/react\` was declared. Under npm's hoisted layout the transitive \`tippy.js@6.3.7\` ended up at the top of \`node_modules\` and resolution worked; under pnpm's stricter layout it doesn't.

Earlier Amplify builds passed because \`amplify.yml\` caches \`node_modules/**/*\` across runs and a once-hoisted copy stayed reachable — this build hit a cache miss and exposed the latent bug.

## Fix
Declare \`tippy.js\` as a direct dependency, pinned to \`6.3.7\` — the same version the lockfile already had transitively, so behavior is unchanged.

This is a **pre-existing latent bug** from the [pnpm migration](https://github.com/Bluetail-aero/cessna-skyhawk/commit/6f0ac99), not introduced by BT-9137. It just surfaced when BT-9137's merge triggered a clean Amplify build. Filing under BT-9137 since that's the blocked deploy.

## Audit
I grepped \`src/\` for every bare import name and compared against \`package.json\`'s dependencies + devDependencies. \`tippy.js\` is the only phantom dep — every other import resolves to a declared package (or a webpack alias).

## Issue
[BT-9137](https://bluetail.atlassian.net/browse/BT-9137)

## Verification
- \`pnpm install\` — clean; lockfile updated to record \`tippy.js\` as a top-level dep (no version change).
- \`pnpm run build:qa\` — \`Compiled successfully.\` (same command Amplify runs).
- \`pnpm lint\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BT-9137]: https://bluetail.atlassian.net/browse/BT-9137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ