### PR TITLE
BT-9155: rename Office Folders harness page to Operations Folders

### DIFF
--- a/src/documentation/hooks/useListOperationsFolders.js
+++ b/src/documentation/hooks/useListOperationsFolders.js
@@ -6,19 +6,19 @@ import { useAuthStore } from 'login/hooks/useAuthStore';
 import { useCallback, useRef } from 'react';
 import { toast } from 'react-toastify';
 
-// /office/list_folders is a POST that takes no body — the company is inferred from the
+// /operations/list_folders is a POST that takes no body — the company is inferred from the
 // OAuth token. We post an empty object so the JSON Content-Type header still applies.
-const listOfficeFolders = async (token) => postApi('/office/list_folders', {}, {
+const listOperationsFolders = async (token) => postApi('/operations/list_folders', {}, {
   headers: {
     Authorization: `Bearer ${token}`,
   },
 });
 
-export const useListOfficeFolders = () => {
+export const useListOperationsFolders = () => {
   const { accessToken, logout } = useAuthStore();
   const toastId = useRef(null);
 
-  const tokenizedApi = useCallback(() => listOfficeFolders(accessToken), [accessToken]);
+  const tokenizedApi = useCallback(() => listOperationsFolders(accessToken), [accessToken]);
 
   const mutation = useMutation({
     mutationFn: tokenizedApi,

--- a/src/navbar/const/apiRoutes.js
+++ b/src/navbar/const/apiRoutes.js
@@ -18,8 +18,8 @@ export const apiRoutes = [
     text: 'Create Aircraft Folder',
     route: '/createAircraftFolder',
   }, {
-    text: 'List Office Folders',
-    route: '/listOfficeFolders',
+    text: 'List Operations Folders',
+    route: '/listOperationsFolders',
   }, {
     text: 'Request Upload',
     route: '/requestUpload',

--- a/src/pages/ListOperationsFolders.jsx
+++ b/src/pages/ListOperationsFolders.jsx
@@ -2,7 +2,7 @@
 import { css } from '@emotion/react';
 import JSONPrettyMon from 'react-json-pretty/dist/monikai';
 import JSONPretty from 'react-json-pretty';
-import { useListOfficeFolders } from 'documentation/hooks/useListOfficeFolders';
+import { useListOperationsFolders } from 'documentation/hooks/useListOperationsFolders';
 import { Button } from '@mui/material';
 import { useCallback } from 'react';
 
@@ -48,7 +48,7 @@ function View({
 }
 
 function Model() {
-  const mutation = useListOfficeFolders();
+  const mutation = useListOperationsFolders();
   const resultJson = mutation?.data?.data?.data || null;
 
   const doSubmit = useCallback((event) => {

--- a/src/router/App.jsx
+++ b/src/router/App.jsx
@@ -9,7 +9,7 @@ import GetMyAccounts from 'pages/GetMyAccounts';
 import SwitchAccount from 'pages/SwitchAccount';
 import ListAircraft from 'pages/ListAircraft';
 import ListAircraftFolders from 'pages/ListAircraftFolders';
-import ListOfficeFolders from 'pages/ListOfficeFolders';
+import ListOperationsFolders from 'pages/ListOperationsFolders';
 import FinalizeUpload from 'pages/FinalizeUpload';
 import RequestUpload from 'pages/RequestUpload';
 import CreateAircraftFolder from 'pages/CreateAircraftFolder';
@@ -45,8 +45,8 @@ function View() {
         element={<ListAircraftFolders />}
       />
       <Route
-        path="/listOfficeFolders"
-        element={<ListOfficeFolders />}
+        path="/listOperationsFolders"
+        element={<ListOperationsFolders />}
       />
       <Route
         path="/requestUpload"


### PR DESCRIPTION
## Summary

Follows [BT-9147](https://bluetail.atlassian.net/browse/BT-9147) which renamed the public-api namespace `/office/list_folders` → `/operations/list_folders`. This PR updates the cessna_skyhawk harness to match:

- Hook + URL: `useListOfficeFolders` → `useListOperationsFolders`, hitting `/operations/list_folders`
- Page component: `ListOfficeFolders.jsx` → `ListOperationsFolders.jsx`
- Client route: `/listOfficeFolders` → `/listOperationsFolders`
- Nav label: "List Office Folders" → "List Operations Folders"

No functional change beyond the URL swap.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — no tests defined in this repo
- [ ] QA: `pnpm start:qa`, log in, navigate to "List Operations Folders" in the sidebar, click "Try it!" → response renders (same shape as before the rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BT-9147]: https://bluetail.atlassian.net/browse/BT-9147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ