### PR TITLE
feat: add deploy changelog notifications to Slack

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -11,6 +11,47 @@ frontend:
         - if [ "${AWS_BRANCH}" = "dev" ]; then pnpm run build:qa; fi
         - if [ "${AWS_BRANCH}" = "staging" ]; then pnpm run build:staging; fi
         - if [ "${AWS_BRANCH}" = "master" ]; then pnpm run build:prod; fi
+    postBuild:
+      commands:
+        # --- Changelog notification to Slack ---
+        # Fetch the last deployed commit from SSM (falls back to HEAD~1 if not set)
+        - |
+          PREV_COMMIT=$(aws ssm get-parameter --name "/amplify/cessna-skyhawk/${AWS_BRANCH}/last-deployed-commit" --query "Parameter.Value" --output text 2>/dev/null || echo "")
+          if [ -z "$PREV_COMMIT" ] || [ "$PREV_COMMIT" = "None" ]; then
+            PREV_COMMIT=$(git rev-parse HEAD~1)
+          fi
+          REPO="Bluetail-aero/cessna-skyhawk"
+          COMMIT_SHORT=$(git rev-parse --short HEAD)
+          COMMIT_LINK="https://github.com/${REPO}/commit/$(git rev-parse HEAD)"
+
+          LINES=""
+          for SHA_FULL in $(git rev-list ${PREV_COMMIT}..HEAD); do
+            SHA_SHORT=${SHA_FULL:0:7}
+            MSG=$(git log --format='%s' -1 "$SHA_FULL")
+            LINK="<https://github.com/${REPO}/commit/${SHA_FULL}|${SHA_SHORT}>"
+            LINES="${LINES}\n• ${LINK} ${MSG}"
+          done
+
+          MESSAGE=":rocket: Amplify build succeeded for \`${REPO}\` on *${AWS_BRANCH}*\nBranch \`${AWS_BRANCH}\` → <${COMMIT_LINK}|${COMMIT_SHORT}>"
+          [ -n "$LINES" ] && MESSAGE="${MESSAGE}\n\n*Commits*${LINES}"
+
+          case "$AWS_BRANCH" in
+            dev)     CHANNEL="feed-qa-deployments" ;;
+            staging) CHANNEL="feed-staging-deployments" ;;
+            master)  CHANNEL="feed-prod-deployments" ;;
+            *)       CHANNEL="" ;;
+          esac
+          if [ -z "$CHANNEL" ] || [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "Skipping Slack notify (branch=$AWS_BRANCH, token set=$([ -n "$SLACK_BOT_TOKEN" ] && echo yes || echo no))"
+          else
+            PAYLOAD=$(jq -n --arg ch "$CHANNEL" --arg text "$(echo -e "$MESSAGE")" '{channel:$ch, text:$text}')
+            curl -s -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "$PAYLOAD"
+          fi
+          # Store current commit as last deployed
+          aws ssm put-parameter --name "/amplify/cessna-skyhawk/${AWS_BRANCH}/last-deployed-commit" --value "$(git rev-parse HEAD)" --type String --overwrite
   artifacts:
     baseDirectory: build
     files:


### PR DESCRIPTION
## Summary
- Adds a `postBuild` step to `amplify.yml` that posts a deploy changelog to Slack after a successful build.
- Uses a shared `SLACK_BOT_TOKEN` and maps `AWS_BRANCH` → channel (`dev` → `#feed-qa-deployments`, `staging` → `#feed-staging-deployments`, `master` → `#feed-prod-deployments`).
- Tracks the previous deployed commit in SSM at `/amplify/cessna-skyhawk/<branch>/last-deployed-commit` so the changelog covers only commits since the last successful deploy.
- Mirrors the approach being added to `app` ([app#1780](https://github.com/Bluetail-aero/app/pull/1780)).

## Required Amplify config
- Env var `SLACK_BOT_TOKEN` (set as secret) — bot must have `chat:write` and be invited to all three channels.
- Build role permissions: `ssm:GetParameter` and `ssm:PutParameter` on `/amplify/cessna-skyhawk/*`.

## Test plan
- [ ] Push to `dev` and confirm a message lands in `#feed-qa-deployments` with the expected commit list.
- [ ] Verify the SSM parameter is created/updated after the build.
- [ ] Second build to `dev` shows only the new commits (not the full history).
- [ ] Repeat on `staging` and `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)