### PR TITLE
BT-9304 fix(demo): drop deprecated legacy folder keys from request defaults

### DIFF
--- a/src/pages/CreateAircraftFolder.jsx
+++ b/src/pages/CreateAircraftFolder.jsx
@@ -11,7 +11,6 @@ import { useCallback, useState } from 'react';
 const defaultJson = {
   name: 'Public',
   type: 'LOGBOOK',
-  parent_key: 'L:6',
   aircraft: {
     tail_number: 'N1000N',
   }

--- a/src/pages/RequestUpload.jsx
+++ b/src/pages/RequestUpload.jsx
@@ -11,7 +11,6 @@ import UploadFileToRequestUploadUrl from 'documentation/components/UploadFileToR
 
 const defaultJson = {
   tail_number: 'N1000N',
-  folder_key: 'C:9',
   file_name: 'Frenchie_310H0104_2021-09-30_10-00-00.pdf',
   prevent_duplicates: false,
 };


### PR DESCRIPTION
## Summary

Removes stale legacy folder-key defaults from the API demo pages. public-api now rejects legacy folder keys (`C:`/`L:`/`O:`) for Freedom Files accounts ([BT-9304](https://bluetail.atlassian.net/browse/BT-9304)), so these defaults caused a **400** on an unedited "Try it!".

- `RequestUpload.jsx` — removed `folder_key: 'C:9'` (uploads now default to the aircraft's Hold Short folder, the same place `C:9` resolved to).
- `CreateAircraftFolder.jsx` — removed `parent_key: 'L:6'` (now creates a top-level folder).

## Test plan

- [ ] Request Upload demo: default JSON no longer contains `folder_key`; "Try it!" against a valid account/aircraft succeeds and the file lands in Hold Short
- [ ] Create Aircraft Folder demo: default JSON no longer contains `parent_key`; "Try it!" creates a top-level folder
- [ ] Both pages: submitting a legacy key entered by hand (`C:9`) now surfaces the public-api 400 (`DeprecatedParameter:folder_key`) rather than appearing to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BT-9304]: https://bluetail.atlassian.net/browse/BT-9304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ